### PR TITLE
👷[ci] Added placeholder CI functionality

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,9 @@
+The contents of this directory are convoluted, as GitHub requires that all workflows reside in this directory (nested directories are not allowed). Therefore, the following naming convention is used for files in the directory:
+
+`callable_`: Callable workflows that are invoked by other workflows in this repository.
+
+`event_`: Workflows that are triggered by an event (pr, push, periodic, etc.).
+
+`manual_`: Workflows that can be triggered by a human on GitHub. These workflows should invoke functionality similar to workflows invoked by events.
+
+`sca_`: Static Code Analysis (SCA) workflows triggered by PRs, commits to mainline branches, and periodic invocations.

--- a/.github/workflows/callable_validate.yaml
+++ b/.github/workflows/callable_validate.yaml
@@ -1,0 +1,27 @@
+name: "[impl] Validates functionality in this repository."
+
+on:
+  workflow_call:
+
+jobs:
+  _ba80c819-dbdd-44d7-a62b-785dab771a5f:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    name: "${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}"
+
+    steps:
+      # Ensure that windows machines support long paths
+      - name: git Long File Path Support on Windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |-
+          git config --system core.longpaths true
+
+      - name: Placeholder
+        run: |-
+          echo "This is a placeholder introduced because GitHub only allows the manual invocation of workflows that exist on the mainline branch. The pull request that includes this file will be merged into the mainline branch and subsequent pull requests will replace this placeholder with actual content that can be verified."

--- a/.github/workflows/event_on_pr.yaml
+++ b/.github/workflows/event_on_pr.yaml
@@ -1,0 +1,12 @@
+name: "on pull request"
+run-name: "${{ github.run_number }} [${{ github.actor }}] ${{ github.head_ref }} -> ${{ github.base_ref }}"
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  _e0837d8d-cb45-43f5-83de-7c1997d74e27:
+    name: "Validate (target: ${{ github.base_ref }})"
+    uses: ./.github/workflows/callable_validate.yaml

--- a/.github/workflows/event_on_push.yaml
+++ b/.github/workflows/event_on_push.yaml
@@ -1,0 +1,12 @@
+name: "on push"
+run-name: "${{ github.run_number }} [${{ github.actor }}] on ${{ github.ref_name }}"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  _eca4b60a-baa0-484d-965f-1f8c005681c1:
+    name: "Validate (${{ github.ref_name }})"
+    uses: ./.github/workflows/callable_validate.yaml

--- a/.github/workflows/event_periodic.yaml
+++ b/.github/workflows/event_periodic.yaml
@@ -1,0 +1,11 @@
+name: "on periodic"
+run-name: "${{ github.run_number }} [${{ github.actor }}] on ${{ github.ref_name }}"
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Once a day at 12am UTC
+
+jobs:
+  _9c21c271-8c8f-4cc9-9827-0034f1132605:
+    name: "Validate (${{ github.ref_name }})"
+    uses: ./.github/workflows/callable_validate.yaml

--- a/.github/workflows/manual_validate.yaml
+++ b/.github/workflows/manual_validate.yaml
@@ -1,0 +1,10 @@
+name: "Validate"
+run-name: "${{ github.run_number }} [${{ github.actor }}] on ${{ github.ref_name }}"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  _61e34512-57b7-4303-81cd-06912ee8a185:
+    name: "Validate (${{ github.ref_name }})"
+    uses: ./.github/workflows/callable_validate.yaml

--- a/.github/workflows/sca_CodeQL.yaml
+++ b/.github/workflows/sca_CodeQL.yaml
@@ -1,0 +1,78 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '24 21 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #     echo "Run, Build Application using script"
+    #     ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
GitHub can only invoke CI workflows that exist on the main branch. This change introduces those workflows, but the workflows themselves don't do much. In future changes, the placeholder content in these workflows will be replaced by actual content.