### PR TITLE
👷 [ci] Disabling CodeQL scans while no python files exist.

### DIFF
--- a/.github/workflows/sca_CodeQL.yaml
+++ b/.github/workflows/sca_CodeQL.yaml
@@ -14,10 +14,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "DisabledUntilPythonFilesExist_master" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "DisabledUntilPythonFilesExist_master" ]
   schedule:
     - cron: '24 21 * * 5'
 


### PR DESCRIPTION
Eventually, this repository will have python files in need of scanning. However, those files don't currently exist and this build task fails as a result.

We are temporarily disabling the task (by forcing it to look at git branches that do not exist). We should undo the effects of this change (by removing the branch name prefix) once python files are introduced into the repository.